### PR TITLE
Drop empty line at the end

### DIFF
--- a/lib/git_diff.ex
+++ b/lib/git_diff.ex
@@ -70,7 +70,8 @@ defmodule GitDiff do
     try do
       parsed_diff =
         git_diff
-        |> String.splitter("\n", trim: true)
+        |> String.trim()
+        |> String.splitter("\n")
         |> split_diffs()
         |> process_diffs()
         |> Enum.to_list()

--- a/lib/git_diff.ex
+++ b/lib/git_diff.ex
@@ -70,7 +70,7 @@ defmodule GitDiff do
     try do
       parsed_diff =
         git_diff
-        |> String.splitter("\n")
+        |> String.splitter("\n", trim: true)
         |> split_diffs()
         |> process_diffs()
         |> Enum.to_list()


### PR DESCRIPTION
Some diffs (here's a link to download the ones I found https://www.dropbox.com/s/a34ffoh6o0fedmt/bad_diffs.zip?dl=0) have an extra empty line at the end, which is incorrectly parsed as a header and then fails.

This PR trims the diff to get rid of those empty lines.