### PR TITLE
Set :to and :from on Patch to be consistent with other renames

### DIFF
--- a/lib/git_diff.ex
+++ b/lib/git_diff.ex
@@ -224,13 +224,13 @@ defmodule GitDiff do
           %{patch | headers: Map.put(patch.headers, "copy to mode", mode)}
 
         "rename from " <> filepath ->
-          %{patch | headers: Map.put(patch.headers, "rename from", filepath)}
+          %{patch | headers: Map.put(patch.headers, "rename from", filepath), from: filepath}
 
         "rename from mode " <> mode ->
           %{patch | headers: Map.put(patch.headers, "rename from mode", mode)}
 
         "rename to " <> filepath ->
-          %{patch | headers: Map.put(patch.headers, "rename to", filepath)}
+          %{patch | headers: Map.put(patch.headers, "rename to", filepath), to: filepath}
 
         "rename to mode " <> mode ->
           %{patch | headers: Map.put(patch.headers, "rename to mode", mode)}


### PR DESCRIPTION
If a file has changed and is renamed, the `Patch` will have `:from` and `:to` defined. For consistency, they should be available on 100% match renames as well.