### PR TITLE
Add streaming API

### DIFF
--- a/test/diff.txt
+++ b/test/diff.txt
@@ -139,7 +139,7 @@ index 10bdef8..181eeb9 100644
    }
  
    // Public: Retrieves the buffer position of where the current word starts.
- diff --git a/lib/mix/tasks/.DS_Store b/lib/mix/tasks/.DS_Store
- new file mode 100644
- index 0000000..5008ddf
- Binary files /dev/null and b/lib/mix/tasks/.DS_Store differ
+diff --git a/lib/mix/tasks/.DS_Store b/lib/mix/tasks/.DS_Store
+new file mode 100644
+index 0000000..5008ddf
+Binary files /dev/null and b/lib/mix/tasks/.DS_Store differ

--- a/test/git_diff_test.exs
+++ b/test/git_diff_test.exs
@@ -8,12 +8,25 @@ defmodule GitDiffTest do
     assert flag == :ok
   end
 
+  test "stream a valid diff" do
+    stream = stream!("test/diff.txt")
+    Enum.to_list(GitDiff.stream_patch(stream))
+  end
+
   test "parse an invalid diff" do
     dir = "test/bad_diffs"
     Enum.each(ls!(dir), fn(file) ->
       text = read!("#{dir}/#{file}")
       {flag, _} = GitDiff.parse_patch(text)
       assert flag == :error
+    end)
+  end
+
+  test "stream an invalid diff" do
+    dir = "test/bad_diffs"
+    Enum.each(ls!(dir), fn(file) ->
+      stream = stream!("#{dir}/#{file}")
+      Enum.to_list(GitDiff.stream_patch(stream))
     end)
   end
 end


### PR DESCRIPTION
This adds a streaming API to git_diff to avoid loading entire diffs into memory. git_diff was already built with streaming internally (thanks for that) so it was pretty straightforward to add the API.

We use this in diff.hex.pm to reduce the memory usage of some requests from 1400MB to 130MB https://github.com/hexpm/diff/pull/46.

I realize there are quite a few changes in this PR so let me know if you want to split things up or drop anything.