### PR TITLE
Fixing parsing a diff when a file is added w/o content

### DIFF
--- a/test/bad_diffs/8.txt
+++ b/test/bad_diffs/8.txt
@@ -1,1 +1,1 @@
-diff --gift /package.json /package.json
+diff --git /package.json /package.json

--- a/test/diff_no_changes_new_file.txt
+++ b/test/diff_no_changes_new_file.txt
@@ -1,0 +1,3 @@
+diff --git a/file_1.txt b/file_1.txt
+new file mode 100644
+index 0000000..e69de29

--- a/test/git_diff_test.exs
+++ b/test/git_diff_test.exs
@@ -39,6 +39,19 @@ defmodule GitDiffTest do
     assert patch.headers["rename to"] == "/tmp/foo/package-phx_new-1.5.7-086C1921/my_app/assets/static/favicon.ico"
   end
 
+  test "reads new files without content" do
+    {:ok, patch} =
+      stream!("test/diff_no_changes_new_file.txt")
+      |> GitDiff.stream_patch()
+      |> Enum.to_list()
+      |> List.last()
+
+    assert patch.from == nil
+    assert patch.to == "/file_1.txt"
+    assert patch.headers["file_a"] == "file_1.txt"
+    assert patch.headers["file_b"] == "file_1.txt"
+  end
+
   test "parse an invalid diff" do
     dir = "test/bad_diffs"
     Enum.each(ls!(dir), fn(file) ->


### PR DESCRIPTION
Hi there! I was trying to use the `GitDiff` library when I came across this bug-- when an empty file is added w/o any content* the patch doesn't have `from` and `to` fields with the expected values.

Not sure if including `file_a` and `file_b` on the headers is the best solution here but it's the one I could find :)

Please let me know if this works out.

Also-- I noticed some files are not `mix format`-compliant**.  Would be happy to fix that as well (maybe on the same PR?)

Best!
Bruno



*like this: 
```
touch file.txt
git add file.txt
git commit -m "adding empty file"
```


** try:
```
mix format --check-formatted lib/git_diff.ex 

** (Mix) mix format failed due to --check-formatted.
The following files are not formatted:

  * lib/git_diff.ex
```