### PR TITLE
Add typespec for GitDiff.Patch

### DIFF
--- a/lib/line.ex
+++ b/lib/line.ex
@@ -3,14 +3,6 @@ defmodule GitDiff.Line do
   Every chunk contains multiple lines, which can be context, added, or removed lines.
   """
 
-  @doc """
-  Defines the Line struct.
-
-  * :from_line_number - The line number preimage.
-  * :to_line_number - The line number postimages.
-  * :text - The text of this line.
-  * :type - The extracted type of line. One of :context, :add, or :remove.
-  """
   defstruct type: nil, from_line_number: nil, to_line_number: nil, text: nil
 
   @typedoc """

--- a/lib/patch.ex
+++ b/lib/patch.ex
@@ -3,7 +3,7 @@ defmodule GitDiff.Patch do
   Every 'git diff' command generates one or more patches.
   """
 
-  @doc """
+  @typedoc """
   Defines the Patch struct.
 
   * :from - The file name preimage.
@@ -11,5 +11,12 @@ defmodule GitDiff.Patch do
   * :headers - A list of headers for the patch.
   * :chunks - A list of chunks of changes contained in this patch. See `GitDiff.Chunk`.
   """
+  @type t :: %__MODULE__{
+    from: String.t() | nil,
+    to: String.t() | nil,
+    headers: %{String.t() => String.t()},
+    chunks: [GitDiff.Chunk.t()]
+  }
+
   defstruct from: nil, to: nil, headers: %{}, chunks: []
 end


### PR DESCRIPTION
This adds a `GitDiff.Patch.t()` typespec so I can reference it in my application's code. It now shows up in the docs like this.

![Screenshot 2023-03-31 at 23-40-50 GitDiff Patch — GitDiff v0 6 4](https://user-images.githubusercontent.com/120878/229267952-1b8c4ed6-fc90-491d-9dbe-c2b35cd0fc62.png)


I also removed the `@doc` attribute for the `defstruct`s because it duplicates the `t/0` types and doesn't share as much information.

| Remove defstruct docs from Patch | Remove defstruct docs from Line |
| -- | -- |
| ![Screenshot 2023-03-31 at 23-41-28 GitDiff Patch — GitDiff v0 6 4](https://user-images.githubusercontent.com/120878/229268083-1819c9a3-e899-4e20-83f4-6e0bcf7c11a4.png) | ![Screenshot 2023-03-31 at 23-41-58 GitDiff Line — GitDiff v0 6 4](https://user-images.githubusercontent.com/120878/229268087-e860fc0b-565c-4316-bf8e-c081fcb82e68.png) |

