### PR TITLE
Add paths to mode changes

### DIFF
--- a/test/git_diff_test.exs
+++ b/test/git_diff_test.exs
@@ -9,16 +9,34 @@ defmodule GitDiffTest do
   end
 
   test "stream a valid diff" do
-    stream = stream!("test/good_diffs/diff.txt")
-    Enum.to_list(GitDiff.stream_patch(stream))
+    stream!("test/good_diffs/diff.txt")
+    |> GitDiff.stream_patch()
+    |> Enum.to_list()
+  end
+
+  test "stream a valid diff with binary file" do
+    stream!("test/good_diffs/diff_binary.txt")
+    |> GitDiff.stream_patch()
+    |> Enum.to_list()
   end
 
   test "relative_from and relative_to adjust patch dirs" do
-    {:ok, patch} =
-      stream!("test/good_diffs/diff.txt")
-      |> GitDiff.stream_patch(relative_to: "/tmp/foo", relative_from: "/tmp/foo")
-      |> Enum.to_list()
-      |> List.last()
+    assert {:ok, patch} =
+             stream!("test/good_diffs/diff_relative.txt")
+             |> GitDiff.stream_patch(relative_to: "/tmp/foo", relative_from: "/tmp/foo")
+             |> Enum.to_list()
+             |> List.last()
+
+    assert patch.from == "package-makeup_elixir-0.16.0-CFBB3C72/hex_metadata.config"
+    assert patch.to == "package-makeup_elixir-0.16.1-A16A070A/hex_metadata.config"
+  end
+
+  test "relative_from and relative_to adjust patch dirs with rename" do
+    assert {:ok, patch} =
+             stream!("test/good_diffs/diff_rename.txt")
+             |> GitDiff.stream_patch(relative_to: "/tmp/foo", relative_from: "/tmp/foo")
+             |> Enum.to_list()
+             |> List.last()
 
     assert patch.from == "package-phx_new-1.0.0-BD5E394E/my_app/web/static/assets/favicon.ico"
     assert patch.to == "package-phx_new-1.5.7-086C1921/my_app/assets/static/favicon.ico"
@@ -31,11 +49,11 @@ defmodule GitDiffTest do
   end
 
   test "reads renames" do
-    {:ok, patch} =
-      stream!("test/good_diffs/diff.txt")
-      |> GitDiff.stream_patch()
-      |> Enum.to_list()
-      |> List.last()
+    assert {:ok, patch} =
+             stream!("test/good_diffs/diff_rename.txt")
+             |> GitDiff.stream_patch()
+             |> Enum.to_list()
+             |> List.last()
 
     assert patch.from ==
              "/tmp/foo/package-phx_new-1.0.0-BD5E394E/my_app/web/static/assets/favicon.ico"
@@ -50,16 +68,31 @@ defmodule GitDiffTest do
   end
 
   test "reads new files without content" do
+    assert {:ok, patch} =
+             stream!("test/good_diffs/diff_no_changes_new_file.txt")
+             |> GitDiff.stream_patch()
+             |> Enum.to_list()
+             |> List.last()
+
+    assert patch.from == nil
+    assert patch.to == "file_1.txt"
+    assert patch.headers["file_a"] == "file_1.txt"
+    assert patch.headers["file_b"] == "file_1.txt"
+  end
+
+  test "reads mode changes" do
     {:ok, patch} =
-      stream!("test/good_diffs/diff_no_changes_new_file.txt")
+      stream!("test/good_diffs/diff_mode_change.txt")
       |> GitDiff.stream_patch()
       |> Enum.to_list()
       |> List.last()
 
-    assert patch.from == nil
-    assert patch.to == "/file_1.txt"
-    assert patch.headers["file_a"] == "file_1.txt"
-    assert patch.headers["file_b"] == "file_1.txt"
+    assert patch.from == "file.txt"
+    assert patch.to == "file.txt"
+    assert patch.headers["file_a"] == "file.txt"
+    assert patch.headers["file_b"] == "file.txt"
+    assert patch.headers["old mode"] == "100755"
+    assert patch.headers["new mode"] == "100644"
   end
 
   test "parse an invalid diff" do

--- a/test/good_diffs/diff.txt
+++ b/test/good_diffs/diff.txt
@@ -139,11 +139,3 @@ index 10bdef8..181eeb9 100644
    }
 
    // Public: Retrieves the buffer position of where the current word starts.
-diff --git a/lib/mix/tasks/.DS_Store b/lib/mix/tasks/.DS_Store
-new file mode 100644
-index 0000000..5008ddf
-Binary files /dev/null and b/lib/mix/tasks/.DS_Store differ
-diff --git a/tmp/foo/package-phx_new-1.0.0-BD5E394E/my_app/web/static/assets/favicon.ico b/tmp/foo/package-phx_new-1.5.7-086C1921/my_app/assets/static/favicon.ico
-similarity index 100%
-rename from /tmp/foo/package-phx_new-1.0.0-BD5E394E/my_app/web/static/assets/favicon.ico
-rename to /tmp/foo/package-phx_new-1.5.7-086C1921/my_app/assets/static/favicon.ico

--- a/test/good_diffs/diff_binary.txt
+++ b/test/good_diffs/diff_binary.txt
@@ -1,0 +1,4 @@
+diff --git a/lib/mix/tasks/.DS_Store b/lib/mix/tasks/.DS_Store
+new file mode 100644
+index 0000000..5008ddf
+Binary files /dev/null and b/lib/mix/tasks/.DS_Store differ

--- a/test/good_diffs/diff_mode_change.txt
+++ b/test/good_diffs/diff_mode_change.txt
@@ -1,0 +1,3 @@
+diff --git a/file.txt b/file.txt
+old mode 100755
+new mode 100644

--- a/test/good_diffs/diff_relative.txt
+++ b/test/good_diffs/diff_relative.txt
@@ -1,0 +1,4 @@
+diff --git a/tmp/foo/package-makeup_elixir-0.16.0-CFBB3C72/hex_metadata.config b/tmp/foo/package-makeup_elixir-0.16.1-A16A070A/hex_metadata.config
+index cf669b9..e15df8f 100644
+--- a/tmp/foo/package-makeup_elixir-0.16.0-CFBB3C72/hex_metadata.config
++++ b/tmp/foo/package-makeup_elixir-0.16.1-A16A070A/hex_metadata.config

--- a/test/good_diffs/diff_rename.txt
+++ b/test/good_diffs/diff_rename.txt
@@ -1,0 +1,4 @@
+diff --git a/tmp/foo/package-phx_new-1.0.0-BD5E394E/my_app/web/static/assets/favicon.ico b/tmp/foo/package-phx_new-1.5.7-086C1921/my_app/assets/static/favicon.ico
+similarity index 100%
+rename from /tmp/foo/package-phx_new-1.0.0-BD5E394E/my_app/web/static/assets/favicon.ico
+rename to /tmp/foo/package-phx_new-1.5.7-086C1921/my_app/assets/static/favicon.ico


### PR DESCRIPTION
This PR does the following things:

* Adds to/from paths when the only file change is the mode.
* Removes header matching for headers that does not seem to exist. I used this list as reference: https://git-scm.com/docs/git-diff#generate_patch_text_with_p.
* Adds a few more tests and moves some of the diff fixtures to dedicated files.